### PR TITLE
Use zsh-style autoloading

### DIFF
--- a/src/_rkt
+++ b/src/_rkt
@@ -36,7 +36,7 @@
 # ------------------------------------------------------------------------------
 
 typeset -A opt_args
-autoload -U regexp-replace
+autoload -Uz regexp-replace
 
 _rkt() {
   _arguments \


### PR DESCRIPTION
This change is for ksh-fans. I've never seen anybody setting `KSH_AUTOLOAD` but I guess some people do. `-z` may not even be necessary in this particular case but it's probably a good idea to use it anyway (rather than checking every time).
